### PR TITLE
Menu UI

### DIFF
--- a/src/app/FlavorGame/Menu/[id]/page.tsx
+++ b/src/app/FlavorGame/Menu/[id]/page.tsx
@@ -95,7 +95,7 @@ export default async function MenuDetailPage({
                         {/* --- Bad UI Element: Confusing Table Layout --- */}
                         <div className="my-8 bg-white text-black p-4 rounded-md max-w-xs mx-auto border border-gray-300">
                             <div className="flex justify-between items-center border-b border-gray-300 pb-2 mb-2">
-                                <h3 className="text-lg font-bold text-gray-800">福神漬もおすすめです</h3>
+                                <h3 className="text-lg font-bold text-yellow-100">福神漬もおすすめです</h3>
                             </div>
                             <div>
                                 {['4袋', '8袋', '36袋'].map((set) => (


### PR DESCRIPTION
メニュー画面のUIをbadにする

完了定義

- 勝手に注文しました(ガチ)
- 読みにくいかき氷説明文
- 福神漬の文章が見にくい
- ラジオボタンと⚪︎が見にくい
- 左下にID(押したらページ移動)
- 右下のボタン(押しても何も起きない)

参考
https://www.610kura.com/SHOP/curry.html
https://ameblo.jp/masasige1616/entry-12371825739.html

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/a7861c72-7c24-4740-92ef-d67682ee872e" />

